### PR TITLE
Use get_posts instead of WP_Query

### DIFF
--- a/public/class-library.php
+++ b/public/class-library.php
@@ -126,18 +126,13 @@ class Library {
 			'post_type' => 'library_term',
 		);
 
-		$query = new WP_Query( $args );
+		$posts = get_posts( $args );
 
 		$output = '';
 
-		if ( $query->have_posts() ) {
-			while ( $query->have_posts() ) {
-				$query->the_post();
-				$output = get_the_content();
-			}
+		foreach ( $posts as $post ) {
+			$output = $post->post_content;
 		}
-
-		wp_reset_postdata();
 
 		return $output;
 	}


### PR DESCRIPTION
Reapplying [7473ed](https://github.com/developdaly/library/commit/a3276b07847a9f3caf95a62a374aef1bf32b2dd9) as I think it got mistakenly overwritten by [4928d8](https://github.com/developdaly/library/commit/4928d8c96cb7c4cac5644f5136eef3e3ec2e0860).

This change stops issues with the query leaking out the loop in certain scenarios (WordPress core uses get_posts for the gallery shortcode).